### PR TITLE
Add loading gif before leaderboard is populated

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
   <h2>Ugly Board</h2>
               <p> I never saw a more ugly leaderboard, we need to work on this! Dah!</p>
   <div id="loader">
-    <img src="https://lingojam.com/img/loading_nice.gif" style="width: 20%;"/>
+    <img src="https://lingojam.com/img/loading_nice.gif" style="width: 15%;"/>
   </div>
   <table id="leaderboard">
     

--- a/index.html
+++ b/index.html
@@ -14,17 +14,11 @@
 <div class="container">
   <h2>Ugly Board</h2>
               <p> I never saw a more ugly leaderboard, we need to work on this! Dah!</p>
+  <div id="loader">
+    <img src="https://lingojam.com/img/loading_nice.gif" style="width: 20%;"/>
+  </div>
   <table id="leaderboard">
-    <thead>
-      <tr>
-        <th>id</th>
-        <th>Points</th>
-       
-      </tr>
-    </thead>
-    <tbody>
-     
-    </tbody>
+    
   </table>
 </div>
 
@@ -39,6 +33,8 @@ xmlhttp.send();
 xmlhttp.onreadystatechange = function() {
     if (this.readyState == 4 && this.status == 200) {
         var myArr = JSON.parse(this.responseText);
+        document.getElementById('leaderboard').innerHTML = '<thead><tr><th>id</th><th>Points</th></tr></thead><tbody></tbody>'; //same as original structure
+        document.getElementById('loader').innerHTML = '';
         addToTable(myArr);
     }
 };


### PR DESCRIPTION
__13__ 

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
<!-- Add issue numbers both above and below this comment, do not remove __ or #-->

Fixes #13

#### Short description of what this resolves:
Adds a loading gif before the leaderboard is populated


#### Changes proposed in this pull request and/or Screenshots of changes:
Live Link: https://madly-jewel.surge.sh/



